### PR TITLE
Change repo status dashboard to use Gitlab

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,9 @@ end
 # Easy access to the Github API
 gem 'octokit'
 
+# Easy access to the Gitlab API
+gem 'gitlab'
+
 # Database config
 gem 'pg', '~> 0.11'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,9 +49,14 @@ GEM
     erubis (2.7.0)
     faraday (0.15.0)
       multipart-post (>= 1.2, < 3)
+    gitlab (4.4.0)
+      httparty (>= 0.14.0)
+      terminal-table (>= 1.5.1)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     hashdiff (0.3.7)
+    httparty (0.16.2)
+      multi_xml (>= 0.5.2)
     i18n (0.9.4)
       concurrent-ruby (~> 1.0)
     jbuilder (2.7.0)
@@ -72,6 +77,7 @@ GEM
       minitest (>= 5.0)
       ruby-progressbar
     multi_json (1.13.1)
+    multi_xml (0.6.0)
     multipart-post (2.0.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
@@ -126,10 +132,13 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    terminal-table (1.8.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
     thor (0.20.0)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    unicode-display_width (1.4.0)
     vcr (4.0.0)
     webmock (3.3.0)
       addressable (>= 2.3.6)
@@ -141,6 +150,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  gitlab
   jbuilder (~> 2.0)
   minitest-reporters
   octokit

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'github_api_service'
+require 'gitlab_api_service'
 
 class WelcomeController < ApplicationController
   REPOS_TO_CHECK = YAML.safe_load(ENV['REPOS_TO_CHECK']).freeze
@@ -15,11 +15,11 @@ class WelcomeController < ApplicationController
 
   def repo_statuses
     @repo_statuses = REPOS_TO_CHECK.map do |repo_hash|
-      details = GithubApiService.repo_details(repo: repo_hash['name'])
+      details = GitlabApiService.repo_details(repo: repo_hash['name'])
       {
         name: details[0],
         descr: details[1],
-        commits: GithubApiService.branch_compare(repo: repo_hash['name'],
+        commits: GitlabApiService.branch_compare(repo: repo_hash['name'],
                                                  base: repo_hash['base'],
                                                  head: repo_hash['head'])
       }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,7 +48,11 @@ footer, .push {
 }
 .repo-list {
   width: 70%;
-  margin: auto;
+  margin: 56px auto;
+}
+.repo-list .updated-at {
+  margin: 10px;
+  text-align: right;
 }
 .repo-list .repo-status {
   padding: 10px;

--- a/app/views/welcome/repo_statuses.html.erb
+++ b/app/views/welcome/repo_statuses.html.erb
@@ -1,4 +1,5 @@
 <div class='repo-list'>
+  <div class="updated-at">Updated at: <%= Time.current.in_time_zone.strftime('%Y-%m-%d %H:%M:%S %Z') %></div>
   <% @repo_statuses.each do |repo_status| %>
     <div class="repo-status <%= repo_class_from_commit_array(repo_status[:commits]) %>">
       <p class="repo-heading"><span class='repo-name'><%= repo_status[:name] %></span> <span class='repo-descr'><%= repo_status[:descr] %></span></p>

--- a/lib/gitlab_api_service.rb
+++ b/lib/gitlab_api_service.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'net/http'
+
+# Service providing methods to query the Gitlab API
+module GitlabApiService
+  # Request the name and description of a repository. Return :not_found if request fails
+  def self.repo_details(repo:)
+    begin
+      repo = client.project repo
+    rescue Gitlab::Error
+      return :not_found
+    end
+
+    [repo.name, repo.description]
+  end
+
+  # Request a comparison between two branches, returning an array of the commit messages
+  # for the commits by which they differ.
+  def self.branch_compare(repo:, base:, head:)
+    begin
+      compare = client.compare(repo, base, head)
+    rescue Gitlab::Error
+      return :not_found
+    end
+
+    compare.commits.map { |c| c['message'] }
+  end
+
+  def self.client
+    @client ||= Gitlab.client(private_token: ENV['GITLAB_API_TOKEN'], httparty: { verify: false })
+    @client
+  end
+end
+
+Gitlab.configure do |c|
+  c.endpoint = ENV['GITLAB_API_URL'] if ENV.key?('GITLAB_API_URL')
+end


### PR DESCRIPTION
I'm hopeful this will run on Heroku where the github one wouldn't. Before merging, tell me so I can set the appropriate environment variables.

Leave Github handler in place, in case we need it in the future. It's not connected to any inbound route.