### PR TITLE
Don't handle add-label if label exists

### DIFF
--- a/lib/pivotal_service.rb
+++ b/lib/pivotal_service.rb
@@ -19,15 +19,17 @@ module PivotalService
   @story_projects = {}
 
   def self.add_reviewed_label(story, user_name)
+    return false if get_reviewed_label(story)
+
     uri = URI.parse(url_for_story(story) + '/labels')
     data = { name: 'reviewed' }
     make_pivotal_post(uri, data)
     write_added_label_comment(story, user_name)
+    true
   end
 
   def self.remove_reviewed_label(story, user_name)
-    labels = get_labels_for_story(story)
-    reviewed_label = labels.detect { |l| l['name'] == 'reviewed' }
+    reviewed_label = get_reviewed_label(story)
     return unless reviewed_label
 
     reviewed_label_id = reviewed_label['id']
@@ -62,6 +64,12 @@ module PivotalService
 
     # Implicitly return proj_id
     @story_projects[story] = proj_id
+  end
+
+  # Find and return the reviewed label for a story, if it exists
+  def self.get_reviewed_label(story)
+    labels = get_labels_for_story(story)
+    labels.detect { |l| l['name'] == 'reviewed' }
   end
 
   def self.get_labels_for_story(story)


### PR DESCRIPTION
We're getting a double-copy of the "Reviewed OK" comment on Pivotal (and the test card in Teams), because Gitlab's MR changed messages are arguably bugged.

This hook works off getting an MR message with a `changes: labels: previous: [], current: [ 'reviewed' ]` structure; but if you add the reviewed label and then later merge the MR, the second message also claims the reviewed label has just been added. So I've tweaked it to check Pivotal before doing anything.