### PR TITLE
Bump rack gem version to address CVE

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
       sawyer (~> 0.8.0, >= 0.5.3)
     pg (0.21.0)
     public_suffix (3.0.2)
-    rack (1.6.10)
+    rack (1.6.11)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.7.1)


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2018-16471